### PR TITLE
fix the emit command by passing the child as first argument

### DIFF
--- a/plan.lua
+++ b/plan.lua
@@ -157,7 +157,7 @@ end
 function Container:emit(event, ...)
   for _, child in ipairs(self.children) do
     if some(child[event]) and type(child[event]) == "function" then
-      local result = child[event](...)
+      local result = child[event](child, ...)
       -- If we return false, then we stop passing this around.
       if result == false then
         return


### PR DESCRIPTION
Container:emit() was placing the first argument of the emitted event into the `self` object due to the nature of the function call. Adding the `child` variable as the first parameter corrects the behavior.

P.S. - loving this library. Been a huge help to me so far!