### PR TITLE
Fixed full rules to have an offset of 0

### DIFF
--- a/plan.lua
+++ b/plan.lua
@@ -406,8 +406,8 @@ function Rules.new()
   local self = setmetatable({}, Rules)
   -- Default to take up full parent.
   self.rules = {
-    x = Plan.parent(),
-    y = Plan.parent(),
+    x = Plan.pixel(0),
+    y = Plan.pixel(0),
     w = Plan.parent(),
     h = Plan.parent(),
   }
@@ -521,8 +521,8 @@ local RuleFactory = {}
 
 function RuleFactory.full()
   local rules = Rules.new()
-  rules:addX(Plan.parent())
-    :addY(Plan.parent())
+  rules:addX(Plan.pixel(0))
+    :addY(Plan.pixel(0))
     :addWidth(Plan.parent())
     :addHeight(Plan.parent())
   return rules


### PR DESCRIPTION
Two of the functions that create rules which take up the whole parent are also offset by the parent's X/Y components. If the parent is offset by 100 pixels from the top left of the screen, a child with the `full` rules will also be offset 100 pixels inside of the parent, which would be 200 pixels from the top left of the screen. This commit replaces the `parent` rules for X/Y with `pixel(0)` under `RuleFactory.full` and `Plan.new`.

Also, thanks for making Plan! It made making UI fun for someone who has a rough time with UI :)